### PR TITLE
Implement Generate Mechanism Command and create rvc-generate task

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,12 @@
     "commands": [
       {
         "command": "robotvibecoder.generateMechanism",
-        "title": "Generate Mechanism"
+        "title": "RobotVibeCoder: Generate Mechanism"
+      }
+    ],
+    "taskDefinitions": [
+      {
+        "type": "rvc-generate"
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,7 +61,7 @@ function ensurePackagePath(pkg: string): string | undefined {
 	const folder = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
 	if (!workspaceUri || !folder) return;
 
-	const configFolderPath = path.join(folder, `src/main/java/frc/robot/${pkg.replace(".", "/")}/`);
+	const configFolderPath = path.normalize(path.join(folder, `src/main/java/frc/robot/${pkg.replace(".", "/")}/`));
 	if (!fs.existsSync(configFolderPath)) {
 		fs.mkdirSync(configFolderPath);
 	}
@@ -76,7 +76,8 @@ function ensurePackagePath(pkg: string): string | undefined {
  * @returns void
  */
 async function executeRVCGenerate(pkg: string, configFilePath: string) {
-	const command = `robotvibecoder -f src/main/java/frc/robot/${pkg.replace(".", "/")} generate -c ${configFilePath}`;
+	const folder = path.normalize(`src/main/java/frc/robot/${pkg.replace(".", "/")}/`)
+	const command = `robotvibecoder -f ${folder} generate -c ${configFilePath}`;
 	const shell = new vscode.ShellExecution(command);
 
 	const workspaceUri = vscode.workspace.workspaceFolders?.[0].uri;


### PR DESCRIPTION
Ctrl+Shift+P -> Generate Mechanism now works, it will generate a mechanism based on the file you currently have open!

Also, instead of opening a terminal and sending the command to it, this PR adds an `rvc-generate` task which opens a terminal for the task that will close when it completes, and doesn't show your prompt/echo the command twice or do any of the other horrible behavior that the old hacky solution included.