### PR TITLE
Escape paths passed to CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "robotvibecoder",
   "displayName": "robotvibecoder",
   "description": "Automatic FRC boilerplate generator",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "publisher": "team401",
   "icon": "icon.png",
   "repository": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -89,7 +89,7 @@ function ensurePackagePath(pkg: string): string | undefined {
 
 async function executeRVCGenerate(pkg: string, configFilePath: string) {
 	const folder = path.normalize(`src/main/java/frc/robot/${pkg.replace(".", "/")}/`);
-	const command = `robotvibecoder -f ${folder} generate -c ${configFilePath}`;
+	const command = `robotvibecoder -f "${folder}" generate -c "${configFilePath}"`;
 	const shell = new vscode.ShellExecution(command);
 
 	const workspaceUri = vscode.workspace.workspaceFolders?.[0].uri;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -88,8 +88,12 @@ function ensurePackagePath(pkg: string): string | undefined {
 }
 
 async function executeRVCGenerate(pkg: string, configFilePath: string) {
-	const folder = path.normalize(`src/main/java/frc/robot/${pkg.replace(".", "/")}/`);
-	const command = `robotvibecoder -f "${folder}" generate -c "${configFilePath}"`;
+	let folder: String = path.normalize(`src/main/java/frc/robot/${pkg.replace(".", "/")}/`);
+	if (folder.endsWith('\\')) {
+		// Remove trailing \ from the string so it doesn't escape the end ' character
+		folder = folder.slice(0, folder.length - 1);
+	}
+	const command = `robotvibecoder -f '${folder}' generate -c '${configFilePath}'`;
 	const shell = new vscode.ShellExecution(command);
 
 	const workspaceUri = vscode.workspace.workspaceFolders?.[0].uri;


### PR DESCRIPTION
Wrap paths passed to CLI in 'single quotes' so that paths with spaces are interpreted as a single argument